### PR TITLE
Small improvements to measure_time

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -17,9 +17,12 @@ module Benchmark
   def self.measure_time(num = 300, &block)
     values = Array.new(num)
     num.times do |i|
-      t1 = monotonic_milliseconds
+      GC.disable
+      t1 = Process.times
       block.call
-      values[i] = monotonic_milliseconds - t1
+      t2 = Process.times
+      GC.enable
+      values[i] = ((t2.utime + t2.stime) - (t1.utime + t1.stime)) * 1000.0
     end
     values
   end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Uses process time rather than wall clock time to get less variable timing measurements.  Also disable garbage collection during timing. Its re-enabled after each iteration to ensure memory does not grow unbounded, but this way the time for GC is not included in the measured times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
